### PR TITLE
Fix travis image/link thingy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Iodized
 
-[![Build Status](https://travis-ci.org/envato/yodado.png)](https://travis-ci.org/envato/yodado)
+[![Build Status](https://travis-ci.org/envato/iodized.png)](https://travis-ci.org/envato/iodized)
 
 ## Getting Started
 


### PR DESCRIPTION
Looks like there was a repo rename and the travis link didnt get updated
