### PR TITLE
Add a not operator.

### DIFF
--- a/lib/iodized/definition.ex
+++ b/lib/iodized/definition.ex
@@ -70,6 +70,16 @@ defmodule Iodized.Definition do
   end
 
 
+  # Not
+  defmodule Not do
+    defstruct definition: nil
+    defimpl Rule, for: Not do
+      def matches?(not_value, state) do
+        not Rule.matches?(not_value.definition, state)
+      end
+    end
+  end
+
   # boolean/nil
   defimpl Rule, for: Atom do
     def matches?(bool, _state) when is_boolean(bool), do: bool

--- a/lib/iodized/definition_json.ex
+++ b/lib/iodized/definition_json.ex
@@ -73,6 +73,21 @@ defmodule Iodized.DefinitionJson do
     end
   end
 
+  defp from_json("not", definition) do
+    definition = Dict.fetch!(definition, :definition)
+    %Iodized.Definition.Not{
+      definition: from_json(definition)
+    }
+  end
+  defimpl Json, for: Iodized.Definition.Not do
+    def to_json(not_key) do
+      %{
+        operand: "not",
+        definition: Json.to_json(not_key.definition)
+      }
+    end
+  end
+
   defimpl Json, for: Atom do
     def to_json(true), do: %{operand: "boolean", value: true}
     def to_json(false), do: %{operand: "boolean", value: false}

--- a/test/iodized/definition_json_test.exs
+++ b/test/iodized/definition_json_test.exs
@@ -77,6 +77,35 @@ defmodule Iodized.DefinitionJsonTest do
 
   end
 
+  defmodule NotTest do
+    use ExUnit.Case, async: true
+    alias Iodized.Definition.Not, as: Not
+
+    test "it serializes" do
+      definition = %Not{definition: true}
+
+      expected_json = "{\"definition\":{\"operand\":\"boolean\",\"value\":true},\"operand\":\"not\"}"
+      actual_json = Json.to_json(definition) |> JSEX.encode!
+      assert actual_json == expected_json
+    end
+
+    test "it deserialises" do
+      json = """
+        {
+          "operand": "not",
+          "definition": {
+            "operand":"is",
+            "param_name":"session_on",
+            "value":"true"
+          }
+        }
+      """
+      actual_definition = json |> JSEX.decode!(labels: :atom) |> Iodized.DefinitionJson.from_json
+      expected_definition = %Not{definition: %Iodized.Definition.Is{actual_state_param_name: "session_on", allowed_value: "true"}}
+      assert(expected_definition === actual_definition)
+    end
+  end
+
   test "parsing from JSON" do
     json = """
       {
@@ -104,9 +133,12 @@ defmodule Iodized.DefinitionJsonTest do
          ]
         },
         {
-         "operand":"is",
-         "param_name":"session_on",
-         "value":"true"
+         "operand": "not",
+         "definition": {
+           "operand":"is",
+           "param_name":"session_on",
+           "value":"true"
+          }
         },
         {
          "operand":"included_in",
@@ -125,7 +157,7 @@ defmodule Iodized.DefinitionJsonTest do
           %Iodized.Definition.IncludedIn{actual_state_param_name: "username", allowed_values: ["madlep", "gstamp"]},
           %Iodized.Definition.IncludedIn{actual_state_param_name: "host", allowed_values: ["themeforest.net", "codecanyon.net"]}
         ]},
-        %Iodized.Definition.Is{actual_state_param_name: "session_on"},
+        %Iodized.Definition.Not{definition: %Iodized.Definition.Is{actual_state_param_name: "session_on"}},
         %Iodized.Definition.IncludedIn{actual_state_param_name: "role", allowed_values: ["developer"]}
       ]}
 

--- a/test/iodized/definition_test.exs
+++ b/test/iodized/definition_test.exs
@@ -103,4 +103,19 @@ defmodule Iodized.DefinitionTest do
       refute(Rule.matches?(definition, state))
     end
   end
+
+  defmodule NotTest do
+    use ExUnit.Case, async: true
+    alias Iodized.Definition.Not, as: Not
+
+    test "is true if the nested definition is false" do
+      definition = %Not{definition: false}
+      assert(Rule.matches?(definition, []))
+    end
+
+    test "is false if the nested definition is true" do
+      definition = %Not{definition: true}
+      refute(Rule.matches?(definition, []))
+    end
+  end
 end


### PR DESCRIPTION
Fixes #23 

Looks something like this:

```
        {
          "operand": "not",
          "definition": {
            "operand":"is",
            "param_name":"session_on",
            "value":"true"
          }
        }
```
