### PR TITLE
None feature

### DIFF
--- a/lib/iodized/definition.ex
+++ b/lib/iodized/definition.ex
@@ -80,17 +80,6 @@ defmodule Iodized.Definition do
     end
   end
 
-
-  # Not
-  defmodule Not do
-    defstruct definition: nil
-    defimpl Rule, for: Not do
-      def matches?(not_value, state) do
-        not Rule.matches?(not_value.definition, state)
-      end
-    end
-  end
-
   # boolean/nil
   defimpl Rule, for: Atom do
     def matches?(bool, _state) when is_boolean(bool), do: bool

--- a/lib/iodized/definition_json.ex
+++ b/lib/iodized/definition_json.ex
@@ -82,21 +82,6 @@ defmodule Iodized.DefinitionJson do
     end
   end
 
-  defp from_json("not", definition) do
-    definition = Dict.fetch!(definition, :definition)
-    %Iodized.Definition.Not{
-      definition: from_json(definition)
-    }
-  end
-  defimpl Json, for: Iodized.Definition.Not do
-    def to_json(not_key) do
-      %{
-        operand: "not",
-        definition: Json.to_json(not_key.definition)
-      }
-    end
-  end
-
   defimpl Json, for: Atom do
     def to_json(true), do: %{operand: "boolean", value: true}
     def to_json(false), do: %{operand: "boolean", value: false}

--- a/test/iodized/definition_json_test.exs
+++ b/test/iodized/definition_json_test.exs
@@ -91,35 +91,6 @@ defmodule Iodized.DefinitionJsonTest do
 
   end
 
-  defmodule NotTest do
-    use ExUnit.Case, async: true
-    alias Iodized.Definition.Not, as: Not
-
-    test "it serializes" do
-      definition = %Not{definition: true}
-
-      expected_json = "{\"definition\":{\"operand\":\"boolean\",\"value\":true},\"operand\":\"not\"}"
-      actual_json = Json.to_json(definition) |> JSEX.encode!
-      assert actual_json == expected_json
-    end
-
-    test "it deserialises" do
-      json = """
-        {
-          "operand": "not",
-          "definition": {
-            "operand":"is",
-            "param_name":"session_on",
-            "value":"true"
-          }
-        }
-      """
-      actual_definition = json |> JSEX.decode!(labels: :atom) |> Iodized.DefinitionJson.from_json
-      expected_definition = %Not{definition: %Iodized.Definition.Is{actual_state_param_name: "session_on", allowed_value: "true"}}
-      assert(expected_definition === actual_definition)
-    end
-  end
-
   test "parsing from JSON" do
     json = """
       {
@@ -137,22 +108,19 @@ defmodule Iodized.DefinitionJsonTest do
            ]
           },
           {
-           "operand":"included_in",
-           "param_name":"host",
-           "value":[
-            "themeforest.net",
-            "codecanyon.net"
+           "operand":"none",
+           "definitions": [
+            {
+             "operand":"included_in",
+             "param_name":"host",
+             "value":[
+              "themeforest.net",
+              "codecanyon.net"
+             ]
+             }
            ]
           }
          ]
-        },
-        {
-         "operand": "not",
-         "definition": {
-           "operand":"is",
-           "param_name":"session_on",
-           "value":"true"
-          }
         },
         {
          "operand":"included_in",
@@ -169,9 +137,9 @@ defmodule Iodized.DefinitionJsonTest do
       %Iodized.Definition.Any{definitions: [
         %Iodized.Definition.All{definitions: [
           %Iodized.Definition.IncludedIn{actual_state_param_name: "username", allowed_values: ["madlep", "gstamp"]},
-          %Iodized.Definition.IncludedIn{actual_state_param_name: "host", allowed_values: ["themeforest.net", "codecanyon.net"]}
+          %Iodized.Definition.None{definitions: [%Iodized.Definition.IncludedIn{actual_state_param_name: "host",
+            allowed_values: ["themeforest.net", "codecanyon.net"]}]},
         ]},
-        %Iodized.Definition.Not{definition: %Iodized.Definition.Is{actual_state_param_name: "session_on"}},
         %Iodized.Definition.IncludedIn{actual_state_param_name: "role", allowed_values: ["developer"]}
       ]}
 

--- a/test/iodized/definition_test.exs
+++ b/test/iodized/definition_test.exs
@@ -133,18 +133,4 @@ defmodule Iodized.DefinitionTest do
     end
   end
 
-  defmodule NotTest do
-    use ExUnit.Case, async: true
-    alias Iodized.Definition.Not, as: Not
-
-    test "is true if the nested definition is false" do
-      definition = %Not{definition: false}
-      assert(Rule.matches?(definition, []))
-    end
-
-    test "is false if the nested definition is true" do
-      definition = %Not{definition: true}
-      refute(Rule.matches?(definition, []))
-    end
-  end
 end


### PR DESCRIPTION
This feature removes the definition of not and adds a none match.  This gives us all the advantages of not with greater consistency and flexibility.
